### PR TITLE
add gcta and plink2 to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM condaforge/mambaforge:latest
 LABEL io.github.snakemake.containerized="true"
-LABEL io.github.snakemake.conda_env_hash="e5e15a739a807ed5368d20504462c433a3036490881814232e4aee2bf799dda1"
+LABEL io.github.snakemake.conda_env_hash="fdabd2690178ff7860dfef3b02463c7607a55214fea9c8f71ce79c3cd9abb87b"
 
 # Step 1: Retrieve conda environments
 
-
 # Conda environment:
 #   source: workflow/envs/r_environment.yml
-#   prefix: /conda-envs/baff2ac264f1f12f7171aed64ac3702e
+#   prefix: /conda-envs/9d0481ef3312907f0c0b2a7736a65351
 #   name: r_finemap
 #   channels:
 #     - conda-forge
@@ -15,6 +14,8 @@ LABEL io.github.snakemake.conda_env_hash="e5e15a739a807ed5368d20504462c433a30364
 #     - defaults
 #     - R
 #   dependencies: #R>=4.3
+#     - plink2=2.00a5.10-0
+#     - gcta=1.94.1-0
 #     - r-base=4.3.3
 #     - r-optparse=1.7.4
 #     - r-tidyverse=2.0.0
@@ -32,10 +33,10 @@ LABEL io.github.snakemake.conda_env_hash="e5e15a739a807ed5368d20504462c433a30364
 #     - r-Matrix=1.6-5
 #     - bioconductor-Gviz=1.46.1
 #     - bioconductor-EnsDb.Hsapiens.v75=2.99.0
-RUN mkdir -p /conda-envs/baff2ac264f1f12f7171aed64ac3702e
-COPY workflow/envs/r_environment.yml /conda-envs/baff2ac264f1f12f7171aed64ac3702e/environment.yaml
+RUN mkdir -p /conda-envs/9d0481ef3312907f0c0b2a7736a65351
+COPY workflow/envs/r_environment.yml /conda-envs/9d0481ef3312907f0c0b2a7736a65351/environment.yaml
 
 # Step 2: Generate conda environments
 
-RUN mamba env create --prefix /conda-envs/baff2ac264f1f12f7171aed64ac3702e --file /conda-envs/baff2ac264f1f12f7171aed64ac3702e/environment.yaml && \
+RUN mamba env create --prefix /conda-envs/9d0481ef3312907f0c0b2a7736a65351 --file /conda-envs/9d0481ef3312907f0c0b2a7736a65351/environment.yaml && \
     mamba clean --all -y

--- a/workflow/envs/r_environment.yml
+++ b/workflow/envs/r_environment.yml
@@ -5,6 +5,8 @@ channels:
   - defaults
   - R
 dependencies: #R>=4.3
+  - plink2=2.00a5.10-0
+  - gcta=1.94.1-0
   - r-base=4.3.3
   - r-optparse=1.7.4
   - r-tidyverse=2.0.0


### PR DESCRIPTION
This PR adds the plink2 and gcta binaries to the Docker image.