### PR TITLE
Skip colocalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Once running the pipeline, `rule run_cojo` will generate output files below:
 - colocalization info table containing credible set variants (with cumulative PPI > 0.99) for each independent variant
 - regional association plots
 
-These outputs are going to be stored in `workspace_path` provided by the user in config_finemap.yaml and stored in such directory: 
+These outputs are going to be stored in `workspace_path` provided by the user in config_finemap.yaml and stored in such directory:
 <workspace_path>/results/*/cojo/<seqid>
 
 
@@ -42,3 +42,7 @@ sbatch submit.sh
 
 ### Not interested to run colocalization?
 If you want to **skip running colocalization** with your traits, uncomment this `#--until collect_credible_sets` in Makefile. If you want to skip both COJO and colocalization and only run locus breaker, then change previous option in Makefile to `--until collect_loci` and run the pipeline as mentioned before.
+
+## Workflow example
+
+<img src="dag.svg" alt="example workflow">

--- a/workflow/rules/cojo.smk
+++ b/workflow/rules/cojo.smk
@@ -87,9 +87,11 @@ rule run_cojo:
         #touch {output.sentinel}
         """
 
+
 rule collect_credible_sets:
     input:
         expand(ws_path("cojo/{seqid}.sentinel"), seqid=analytes.seqid),
+        rules.collect_loci.output.ofile,
     output:
         ofile=ws_path("cojo/collected_credible_sets.csv"),
     conda:
@@ -98,5 +100,3 @@ rule collect_credible_sets:
         runtime=lambda wc, attempt: 999 + attempt * 60,
     script:
         "../scripts/s04_collect_credible_sets.R"
-
-


### PR DESCRIPTION
This PR will trigger the execution of the collect_loci when the `--until collect_credible_sets` argument is set in the command line. It also adds an example of a dag.